### PR TITLE
Configure ports for auth-service and api-gateway

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log
 testem.log
 /typings
 
+# environment variables
+.env
+
 # System Files
 .DS_Store
 Thumbs.db

--- a/apps/api-getway/src/main.ts
+++ b/apps/api-getway/src/main.ts
@@ -1,8 +1,3 @@
-/**
- * This is not a production server yet!
- * This is only a minimal backend to get started.
- */
-
 import express from 'express';
 import * as path from 'path';
 
@@ -14,7 +9,7 @@ app.get('/api', (req, res) => {
   res.send({ message: 'Welcome to api-getway!' });
 });
 
-const port = process.env.PORT || 3333;
+const port = process.env.API_PORT || 8080;
 const server = app.listen(port, () => {
   console.log(`Listening at http://localhost:${port}/api`);
 });

--- a/apps/auth-service/src/main.ts
+++ b/apps/auth-service/src/main.ts
@@ -1,7 +1,7 @@
 import express from 'express';
 
 const host = process.env.HOST ?? 'localhost';
-const port = process.env.PORT ? Number(process.env.PORT) : 3000;
+const port = process.env.AUTH_PORT ? Number(process.env.AUTH_PORT) : 6001;
 
 const app = express();
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "@e-shop/source",
   "version": "0.0.0",
   "license": "MIT",
-  "scripts": {},
+  "scripts": {
+    "dev": "npx nx run-many --target=serve --all"
+  },
   "private": true,
   "dependencies": {
     "axios": "^1.6.0",


### PR DESCRIPTION
### Purpose
This PR externalizes the port configuration for the microservices to prevent local development conflicts and allow for environment-specific setups. It ensures that the `auth-service` and `api-gateway` run on distinct, non-default ports.

### Related Issues
- Resolves #2

### Approach
- Updated `apps/auth-service/src/main.ts` to use `process.env.AUTH_PORT` (defaulting to **6001**).
- Updated `apps/api-gateway/src/main.ts` to use `process.env.API_PORT` (defaulting to **8080**).
- Added `.env` to `.gitignore` to ensure local secrets are not committed to version control.

### Application Structure Changes
- **Configuration**: Services now rely on environment variables for port binding.

### Testing Performed
- [x] Created a local `.env` file with custom ports.
- [x] Ran `nx run-many -t serve` to verify services start without `EADDRINUSE` errors.
- [x] Verified `auth-service` is listening on localhost:6001.
- [x] Verified `api-gateway` is listening on localhost:8080.
- [x] Verified `git status` ignores the `.env` file.