### PR TITLE
Apply global formatting and linting fixes

### DIFF
--- a/apps/api-getway-e2e/jest.config.cts
+++ b/apps/api-getway-e2e/jest.config.cts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { readFileSync } from 'fs';
 
 // Reading the SWC compilation config for the spec files

--- a/apps/api-getway-e2e/src/support/global-teardown.ts
+++ b/apps/api-getway-e2e/src/support/global-teardown.ts
@@ -1,5 +1,4 @@
 import { killPort } from '@nx/node/utils';
-/* eslint-disable */
 
 module.exports = async function () {
   // Put clean up logic here (e.g. stopping services, docker-compose, etc.).

--- a/apps/api-getway-e2e/src/support/test-setup.ts
+++ b/apps/api-getway-e2e/src/support/test-setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import axios from 'axios';
 
 module.exports = async function () {

--- a/apps/auth-service-e2e/jest.config.cts
+++ b/apps/auth-service-e2e/jest.config.cts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import { readFileSync } from 'fs';
 
 // Reading the SWC compilation config for the spec files

--- a/apps/auth-service-e2e/src/support/global-teardown.ts
+++ b/apps/auth-service-e2e/src/support/global-teardown.ts
@@ -1,5 +1,4 @@
 import { killPort } from '@nx/node/utils';
-/* eslint-disable */
 
 module.exports = async function () {
   // Put clean up logic here (e.g. stopping services, docker-compose, etc.).

--- a/apps/auth-service-e2e/src/support/test-setup.ts
+++ b/apps/auth-service-e2e/src/support/test-setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 import axios from 'axios';
 
 module.exports = async function () {

--- a/apps/auth-service/jest.config.cts
+++ b/apps/auth-service/jest.config.cts
@@ -1,4 +1,3 @@
-/* eslint-disable */
 const { readFileSync } = require('fs');
 
 // Reading the SWC compilation config for the spec files


### PR DESCRIPTION
### Purpose
This PR standardizes the codebase by applying the newly added formatting and linting scripts across the entire workspace. It ensures that all files adhere to the project's style guidelines defined by Prettier and ESLint.

### Related Issues
- Resolves #5

### Approach
- Ran `npm run format` to apply Prettier formatting to all supported files.
- Ran `npm run lint:fix` to automatically correct ESLint violations in source files.

### Testing Performed
- Ran `npm run lint` after fixes to ensure no errors remain.
- Ran `npm run dev` to verify that formatting changes did not break application startup.