### PR TITLE
Fix Next.js app missing serve target in Nx configuration

### DIFF
--- a/apps/e-shop-web/next-env.d.ts
+++ b/apps/e-shop-web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/e-shop-web/package.json
+++ b/apps/e-shop-web/package.json
@@ -6,25 +6,39 @@
     "targets": {
       "build": {
         "executor": "@nx/next:build",
-        "outputs": ["{projectRoot}/.next"],
+        "outputs": [
+          "{projectRoot}/.next"
+        ],
         "defaultConfiguration": "production",
-        "options": {},
+        "options": {
+          "outputPath": ".next"
+        },
         "configurations": {
-          "development": {},
-          "production": {}
+          "development": {
+            "outputPath": ".next"
+          },
+          "production": {
+            "outputPath": ".next"
+          }
         }
       },
       "serve": {
         "executor": "@nx/next:server",
         "defaultConfiguration": "development",
         "options": {
+          "buildTarget": "build",
+          "outputPath": ".next",
           "dev": true
         },
         "configurations": {
           "development": {
+            "buildTarget": "build:development",
+            "outputPath": ".next",
             "dev": true
           },
           "production": {
+            "buildTarget": "build:production",
+            "outputPath": ".next",
             "dev": false
           }
         }


### PR DESCRIPTION
This PR adds the missing Nx build and serve targets to the e-shop-web package.json, ensuring the frontend starts correctly during full-stack development.

* Configure @nx/next:build and @nx/next:server targets for e-shop-web
* Fix issue where npm run dev skipped the frontend application
* Ensure all 3 projects run simultaneously via nx run-many

Resolves: #26